### PR TITLE
DAOTHER-4321 

### DIFF
--- a/wwpdb/utils/emdb/cif_emdb_translator/generatedsnamespaces.py
+++ b/wwpdb/utils/emdb/cif_emdb_translator/generatedsnamespaces.py
@@ -1,6 +1,5 @@
 # file: generatedsnamespaces.py
 
 GenerateDSNamespaceDefs = {
-    "emd": 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
-    "emd": 'xsi:schemaLocation="https://github.com/emdb-empiar/emdb-schemas/blob/master/v3/v3_0_1_4/emdb.xsd"',
+    "entry_type": 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/emdb-empiar/emdb-schemas/blob/master/v3/v3_0_1_4/emdb.xsd"',
 }


### PR DESCRIPTION
Xml schema location was not being added in onedep, changed to ensure it is properly added.
The issue was that the generateDSNamespaceDefs was not properly configured.

Signed-off-by: Ryan-Pye <ryan@ebi.ac.uk>