### PR TITLE
fix: process all database references in other_db_list, not just SASBDB

### DIFF
--- a/wwpdb/utils/emdb/cif_emdb_translator/cif_emdb_translator.py
+++ b/wwpdb/utils/emdb/cif_emdb_translator/cif_emdb_translator.py
@@ -3713,8 +3713,9 @@ class CifEMDBTranslator(object):
                         """
                         set_cif_value(other_db_ref.set_details, "details", const.PDBX_DATABASE_RELATED, cif_list=other_db_ref_in)
 
-                    if "SASBDB" in other_db_ref_dict_in:
-                        other_db_ref_list_in = other_db_ref_dict_in["SASBDB"]
+                    # Process all databases in other_db_ref_dict_in, not just SASBDB
+                    for db_name in other_db_ref_dict_in:
+                        other_db_ref_list_in = other_db_ref_dict_in[db_name]
                         for other_db_ref_in in other_db_ref_list_in:
                             other_db_ref = emdb.other_db_cross_reference_type()
                             set_ref_el_db_name(other_db_ref, other_db_ref_in)

--- a/wwpdb/utils/emdb/cif_emdb_translator/data/cif/EMD-0000.cif
+++ b/wwpdb/utils/emdb/cif_emdb_translator/data/cif/EMD-0000.cif
@@ -274,7 +274,9 @@ _pdbx_database_related.db_id
 _pdbx_database_related.content_type 
 EMDB . EMD-90288 'associated EM volume' 
 EMDB ? EMD-12345 'consensus EM volume'  
-EMDB ? EMD-12346 'focused EM volume'    
+EMDB ? EMD-12346 'focused EM volume'
+NOR ? NOR00639 'norine database reference'
+SASBDB ? SASVGQ 'SASBDB database reference'
 # 
 _citation.abstract                  ? 
 _citation.abstract_id_CAS           ? 


### PR DESCRIPTION
Previously, the CIF-to-XML translator only processed SASBDB entries in the other_db_list section, causing other database references (like NOR/Norine) to fall through to struct_ref processing and generate schema validation errors when mapped to external_references with unsupported enumeration values.

Modified set_other_db_cross_ref_list_type() to iterate through all database names in other_db_ref_dict_in instead of hardcoding only "SASBDB", ensuring all database references from _pdbx_database_related are correctly placed in the <other_db_list> section of the output XML.

Fixes schema validation errors for entries containing Norine (NOR) and other non-SASBDB database references that were previously blocked during release.