### PR TITLE
DAOTHER-10045: support negative residue ranges in EMDB schema validation

### DIFF
--- a/wwpdb/utils/emdb/cif_emdb_translator/data/cif/EMD-0000.cif
+++ b/wwpdb/utils/emdb/cif_emdb_translator/data/cif/EMD-0000.cif
@@ -423,6 +423,17 @@ _em_3d_fitting.ref_space                     ?
 _em_3d_fitting.ref_protocol                  ? 
 _em_3d_fitting.initial_refinement_model_id   ? 
 #
+loop_
+_em_3d_fitting_list.id
+_em_3d_fitting_list.3d_fitting_id
+_em_3d_fitting_list.pdb_entry_id
+_em_3d_fitting_list.pdb_chain_id
+_em_3d_fitting_list.pdb_chain_residue_range
+_em_3d_fitting_list.chain_residue_range
+_em_3d_fitting_list.details
+1 1 4v19 A -59-0 -59-0 'Test negative residue range'
+2 1 4v19 B 1-100 1-100 'Test positive residue range'
+#
 _em_fsc_curve.id    1
 _em_fsc_curve.details  "FSC"
 _em_fsc_curve.file  "emd_0000_fsc_1.xml"

--- a/wwpdb/utils/emdb/cif_emdb_translator/emdb.py
+++ b/wwpdb/utils/emdb/cif_emdb_translator/emdb.py
@@ -2,21 +2,21 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Apr  7 12:12:28 2025 by generateDS.py version 2.44.3.
+# Generated Thu Jun 26 14:52:08 2025 by generateDS.py version 2.44.3.
 # Python 3.10.9 (main, Mar  1 2023, 12:33:47) [Clang 14.0.6 ]
 #
 # Command line options:
 #   ('--root-element', 'emd')
 #   ('-f', '')
-#   ('-o', 'emdb_schemas/v3/v3_0_11_0/emdb.py')
+#   ('-o', 'emdb_schemas/v3/v3_0_11_1/emdb.py')
 #   ('--no-warnings', '')
 #   ('--external-encoding', 'utf-8')
 #
 # Command line arguments:
-#   emdb_schemas/v3/v3_0_11_0/emdb.xsd
+#   emdb_schemas/v3/v3_0_11_1/emdb.xsd
 #
 # Command line:
-#   /Users/lucas/anaconda3/bin/generateDS --root-element="emd" -f -o "emdb_schemas/v3/v3_0_11_0/emdb.py" --no-warnings --external-encoding="utf-8" emdb_schemas/v3/v3_0_11_0/emdb.xsd
+#   /Users/lucas/anaconda3/bin/generateDS --root-element="emd" -f -o "emdb_schemas/v3/v3_0_11_1/emdb.py" --no-warnings --external-encoding="utf-8" emdb_schemas/v3/v3_0_11_1/emdb.xsd
 #
 # Current working directory (os.getcwd()):
 #   emdb-schemas
@@ -1829,7 +1829,7 @@ class entry_type(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     subclass = None
     superclass = None
-    def __init__(self, emdb_id=None, version='3.0.11.0', admin=None, crossreferences=None, sample=None, structure_determination_list=None, map=None, interpretation=None, validation=None, gds_collector_=None, **kwargs_):
+    def __init__(self, emdb_id=None, version='3.0.11.1', admin=None, crossreferences=None, sample=None, structure_determination_list=None, map=None, interpretation=None, validation=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1955,7 +1955,7 @@ class entry_type(GeneratedsSuper):
         if self.emdb_id is not None and 'emdb_id' not in already_processed:
             already_processed.add('emdb_id')
             outfile.write(' emdb_id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.emdb_id), input_name='emdb_id')), ))
-        if self.version != "3.0.11.0" and 'version' not in already_processed:
+        if self.version != "3.0.11.1" and 'version' not in already_processed:
             already_processed.add('version')
             outfile.write(' version=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.version), input_name='version')), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='entry_type', fromsubclass_=False, pretty_print=True):
@@ -18980,7 +18980,7 @@ class chain_type(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_residue_rangeType_patterns_, ))
                 result = False
         return result
-    validate_residue_rangeType_patterns_ = [['^(\\d+-\\d+)$']]
+    validate_residue_rangeType_patterns_ = [['^([+-]?[0-9]+-[+-]?[0-9]+)$']]
     def has__content(self):
         if (
             self.chain_id or
@@ -45120,7 +45120,7 @@ class chainType(GeneratedsSuper):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_residue_rangeType66_patterns_, ))
                 result = False
         return result
-    validate_residue_rangeType66_patterns_ = [['^(\\d+-\\d+)$']]
+    validate_residue_rangeType66_patterns_ = [['^([+-]?[0-9]+-[+-]?[0-9]+)$']]
     def validate_source_nameType(self, value):
         result = True
         # Validate type source_nameType, a restriction on xs:string.

--- a/wwpdb/utils/emdb/cif_emdb_translator/emdb.xsd
+++ b/wwpdb/utils/emdb/cif_emdb_translator/emdb.xsd
@@ -25,7 +25,7 @@
             </xs:element>
         </xs:sequence>
         <xs:attribute name="emdb_id" type="emdb_id_type" use="required"/>
-        <xs:attribute name="version" type="xs:token" default="3.0.11.0"/>
+        <xs:attribute name="version" type="xs:token" default="3.0.11.1"/>
     </xs:complexType>
     <xs:complexType name="admin_type">
         <xs:sequence>
@@ -3466,7 +3466,7 @@
             <xs:element name="residue_range" minOccurs="0" maxOccurs="1">
                 <xs:simpleType>
                     <xs:restriction base="xs:token">
-                        <xs:pattern value="\d+-\d+"/>
+                        <xs:pattern value="[+-]?[0-9]+-[+-]?[0-9]+"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
@@ -3528,30 +3528,6 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <!-- <xs:element name="id" type="xs:string" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        PRIMARY KEY
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="[][_,.;:&lt;&gt;()/\{}'`~!@#$%A-Za-z0-9*|+-]*"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="image_processing_id" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        Pointer to _em_image_processing.id in the EM_IMAGE_PROCESSING category.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="[][_,.;:&lt;&gt;()/\{}'`~!@#$%A-Za-z0-9*|+-]*"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element> -->
             <xs:element name="type" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -3696,7 +3672,6 @@
             <xs:element name="final_reconstruction" type="non_subtom_final_reconstruction_type"
                 minOccurs="0"/>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="segment_selection" type="segment_selection_type" minOccurs="0"
                 maxOccurs="unbounded"/>
@@ -3843,7 +3818,6 @@
             <xs:element name="particle_selection" type="particle_selection_type" minOccurs="0"
                 maxOccurs="unbounded"/>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="startup_model" type="starting_map_type" minOccurs="0"
                 maxOccurs="unbounded"/>
@@ -3925,7 +3899,6 @@
                 </xs:complexType>
             </xs:element>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="final_multi_reference_alignment" minOccurs="0">
                 <xs:complexType>
@@ -4007,7 +3980,6 @@
                 minOccurs="0"/>
             <xs:element name="series_aligment_software_list" type="software_list_type" minOccurs="0"/>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="crystal_parameters" type="crystal_parameters_type" minOccurs="0"/>
         </xs:sequence>
@@ -4238,7 +4210,7 @@
                                     <xs:element minOccurs="0" name="residue_range">
                                         <xs:simpleType>
                                             <xs:restriction base="xs:token">
-                                                <xs:pattern value="\d+-\d+"/>
+                                                <xs:pattern value="[+-]?[0-9]+-[+-]?[0-9]+"/>
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:element>

--- a/wwpdb/utils/emdb/data/emdb-v3.xsd
+++ b/wwpdb/utils/emdb/data/emdb-v3.xsd
@@ -25,7 +25,7 @@
             </xs:element>
         </xs:sequence>
         <xs:attribute name="emdb_id" type="emdb_id_type" use="required"/>
-        <xs:attribute name="version" type="xs:token" default="3.0.11.0"/>
+        <xs:attribute name="version" type="xs:token" default="3.0.11.1"/>
     </xs:complexType>
     <xs:complexType name="admin_type">
         <xs:sequence>
@@ -3466,7 +3466,7 @@
             <xs:element name="residue_range" minOccurs="0" maxOccurs="1">
                 <xs:simpleType>
                     <xs:restriction base="xs:token">
-                        <xs:pattern value="\d+-\d+"/>
+                        <xs:pattern value="[+-]?[0-9]+-[+-]?[0-9]+"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
@@ -3528,30 +3528,6 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <!-- <xs:element name="id" type="xs:string" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        PRIMARY KEY
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="[][_,.;:&lt;&gt;()/\{}'`~!@#$%A-Za-z0-9*|+-]*"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="image_processing_id" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        Pointer to _em_image_processing.id in the EM_IMAGE_PROCESSING category.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="[][_,.;:&lt;&gt;()/\{}'`~!@#$%A-Za-z0-9*|+-]*"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element> -->
             <xs:element name="type" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -3696,7 +3672,6 @@
             <xs:element name="final_reconstruction" type="non_subtom_final_reconstruction_type"
                 minOccurs="0"/>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="segment_selection" type="segment_selection_type" minOccurs="0"
                 maxOccurs="unbounded"/>
@@ -3843,7 +3818,6 @@
             <xs:element name="particle_selection" type="particle_selection_type" minOccurs="0"
                 maxOccurs="unbounded"/>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="startup_model" type="starting_map_type" minOccurs="0"
                 maxOccurs="unbounded"/>
@@ -3925,7 +3899,6 @@
                 </xs:complexType>
             </xs:element>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="final_multi_reference_alignment" minOccurs="0">
                 <xs:complexType>
@@ -4007,7 +3980,6 @@
                 minOccurs="0"/>
             <xs:element name="series_aligment_software_list" type="software_list_type" minOccurs="0"/>
             <xs:element name="ctf_correction" type="ctf_correction_type" minOccurs="0"/>
-            <!-- Add motion_correction of motion_correction_type-->
             <xs:element name="motion_correction" type="motion_correction_type" minOccurs="0"/>
             <xs:element name="crystal_parameters" type="crystal_parameters_type" minOccurs="0"/>
         </xs:sequence>
@@ -4238,7 +4210,7 @@
                                     <xs:element minOccurs="0" name="residue_range">
                                         <xs:simpleType>
                                             <xs:restriction base="xs:token">
-                                                <xs:pattern value="\d+-\d+"/>
+                                                <xs:pattern value="[+-]?[0-9]+-[+-]?[0-9]+"/>
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:element>


### PR DESCRIPTION
Update EMDB v3.x schema files to accept negative residue ranges by modifying the regex pattern from '\d+-\d+' to '[+-]?[0-9]+-[+-]?[0-9]+'. This allows valid mmCIF residue ranges like '-59-0' to pass XML schema validation during CIF-to-XML translation.

Changes:
- Update residue_range pattern in emdb-v3.xsd (main schema)
- Update residue_range pattern in emdb.xsd (local test schema)
- Both patterns now support optional leading signs for negative numbers

Fixes: Schema validation errors for negative residue ranges in em_3d_fitting_list
Tested: CIF-to-XML translation with test data containing '-59-0' range
Validates: Generated XML passes xmllint validation against updated schema